### PR TITLE
Feat-Admin-approves/reject-loanRequest

### DIFF
--- a/server/controllers/admin.js
+++ b/server/controllers/admin.js
@@ -104,7 +104,8 @@ class AdminController {
       data: sortLoan
     });
   }
-    /*
+
+  /*
       * @method getLoansById
 
        * @description get a specific loan applications in the database
@@ -135,7 +136,35 @@ class AdminController {
       data: foundId,
     });
   }
+  /**
+     * changes loan status
+     * @param {object} request express request object
+     * @param {object} response express response object
+     *
+     * @returns {json} json
+     * @memberof userController
+     */
 
+  // eslint-disable-next-line consistent-return
+  static loanVerify(request, response) {
+    const { status } = request.body;
+    const { id } = request.params;
+    const userId = Number(id);
+
+    const foundId = help.searchById(userId, data.loans);
+    if (!foundId) {
+      return response.status(404).json({
+        status: statusCodes.notFound,
+        error: 'Id does not exists',
+      });
+    }
+
+    foundId.status = status;
+    response.status(200).json({
+      status: statusCodes.success,
+      data: foundId
+    });
+  }
 }
 
 export default AdminController;

--- a/server/middleware/loan_validation.js
+++ b/server/middleware/loan_validation.js
@@ -54,7 +54,7 @@ class loanValidate {
     }
     next();
   }
-  
+
   static loanQuery(request, response, next) {
     /* check if query parimeter is empty  return all loan */
 
@@ -103,6 +103,26 @@ class loanValidate {
     }
 
     return next();
+  }
+
+  // eslint-disable-next-line consistent-return
+  static loanStatusChange(request, response, next) {
+    const { status } = request.body;
+    if (!status || status.trim().length === 0) {
+      return response.status(400).json({
+        status: statusCodes.badRequest,
+        error: 'No status selected',
+      });
+    }
+
+    if (status !== 'approved' && status !== 'declined') {
+      return response.status(400).json({
+        status: statusCodes.badRequest,
+        error: 'Wrong status selected',
+      });
+    }
+
+    next();
   }
 }
 export default loanValidate;

--- a/server/route/index.js
+++ b/server/route/index.js
@@ -27,8 +27,10 @@ const route = (app) => {
   app.post(`${API_VERSION}/loans`, loan.validateLoanRequest, loans.loanrequest);
   // Admin can get all loan request
   app.get(`${API_VERSION}/loans`, auth.authentication, auth.adminRole, loan.loanQuery, admin.getAllLoans);
-    // Admin can get a specific loan request
-    app.get(`${API_VERSION}/loans/:id/`, auth.authentication, auth.adminRole, admin.getLoansById);
+  // Admin can get a specific loan request
+  app.get(`${API_VERSION}/loans/:id/`, auth.authentication, auth.adminRole, admin.getLoansById);
+  // Admin can Approve or Reject loans
+  app.patch(`${API_VERSION}/loan/:id/`, auth.authentication, auth.adminRole, loan.loanStatusChange, admin.loanVerify);
 };
 
 export default route;


### PR DESCRIPTION
What does this PR do?
Allow admin to approve/decline a  specific loans in the database

Description of Task to be completed?
An endpoint that allows only an admin user access to the database to approve/decline specific users

How should this be manually tested?
postman and heroku
Any background context you want to provide?
None >>>heroku
change last screenshot the endpoint was approved now declined
What are the relevant pivotal tracker stories?
none
An endpoint where Admin can verify loan application
![approvl loans](https://user-images.githubusercontent.com/31935467/57853469-c3533a00-77dd-11e9-9165-d2e62af8d1c0.PNG)


[Delivers #165990516]