### PR TITLE
feat user can make payment

### DIFF
--- a/server/controllers/loan.js
+++ b/server/controllers/loan.js
@@ -59,6 +59,52 @@ class loan {
       },
     });
   }
+   /**
+   * Pay for loan
+   * @param {object} request express request object
+   * @param {object} response express response object
+   *
+   * @returns {json} json
+   * @memberof Loan
+   */
+
+  // eslint-disable-next-line consistent-return
+  static payLoan(request, response) {
+    const { amount } = request.body;
+    const { id } = request.params;
+    const userId = Number(id, 0);
+    const amountPaid = Number(amount);
+    const foundId = help.searchById(userId, data.loans);
+
+    if (!foundId) {
+      return response.status(400).json({
+        status: statusCodes.badRequest,
+        error: 'User does not exists',
+      });
+    }
+
+    const loanData = {
+      id: help.getNextId(data.payment),
+      createdOn: moment().format(),
+      loanId: id,
+      recentPayment: amountPaid,
+      monthlypayment: foundId.paymentInstallation,
+      status: 'Unapproved'
+    };
+    data.payment.push(loanData);
+
+    response.status(200).json({
+      status: statusCodes.success,
+      data: {
+        id: loanData.id,
+        createdOn: loanData.createdOn,
+        loanId: loanData.loanId,
+        amountPaid: loanData.recentPayment,
+        status: loanData.status,
+      },
+    });
+  }
+
 }
 
 export default loan;

--- a/server/middleware/loan_validation.js
+++ b/server/middleware/loan_validation.js
@@ -1,3 +1,4 @@
+/* eslint-disable consistent-return */
 import statusCodes from '../helpers/statuscodes';
 
 /**
@@ -122,6 +123,17 @@ class loanValidate {
       });
     }
 
+    next();
+  }
+
+  static payment(request, response, next) {
+    const { amount } = request.body;
+    if (amount === undefined || amount === '' || amount === null) {
+      return response.status(400).json({
+        status: statusCodes.badRequest,
+        error: 'amount is required',
+      });
+    }
     next();
   }
 }

--- a/server/route/index.js
+++ b/server/route/index.js
@@ -31,6 +31,8 @@ const route = (app) => {
   app.get(`${API_VERSION}/loans/:id/`, auth.authentication, auth.adminRole, admin.getLoansById);
   // Admin can Approve or Reject loans
   app.patch(`${API_VERSION}/loan/:id/`, auth.authentication, auth.adminRole, loan.loanStatusChange, admin.loanVerify);
+  //  Users can pay loans
+  app.post(`${API_VERSION}/loans/:id/repayment`, loan.payment, loans.payLoan);
 };
 
 export default route;


### PR DESCRIPTION
### What does this PR do?
Allow a User to be able to make a loan payment from his/her accout page

### Description of Task to be completed?
WHEN a new User pay monthly installation from quickcredit application anywhere in the world
THEN QuickCredit should post endpoint return User's loan payment successful awaiting approval

### How should this be manually tested?
postman and heroku

### Any background context you want to provide?
None >>>heroku

### What are the relevant pivotal tracker stories?
none
![payment](https://user-images.githubusercontent.com/31935467/57855460-a836f900-77e2-11e9-9c4f-55cb4a914d18.PNG)


An endpiont to receive user payment information

[Delivers 166058193]