### PR TITLE
Feat admin can get allpayment history

### DIFF
--- a/server/controllers/admin.js
+++ b/server/controllers/admin.js
@@ -217,6 +217,34 @@ class AdminController {
       });
     }
   }
+    /**
+
+     * @method getAllPayment
+
+     * @description List all loan applications in the database
+
+     * @param {object} request - The Request Object
+
+     * @param {object} response - The Response Object
+
+     * @returns {object} JSON API Response
+
+     */
+
+    static getAllPayment(request, response) {
+      const paymentData = data.payment;
+      if (paymentData.length < 0) {
+        return response.status(404).json({
+          status: statusCodes.notFound,
+          error: 'No payment record',
+        });
+      }
+      return response.status(200).json({
+        status: statusCodes.success,
+        data: paymentData,
+      });
+    }
+  }
 }
 
 export default AdminController;

--- a/server/route/index.js
+++ b/server/route/index.js
@@ -32,9 +32,11 @@ const route = (app) => {
   // Admin can Approve or Reject loans
   app.patch(`${API_VERSION}/loan/:id/`, auth.authentication, auth.adminRole, loan.loanStatusChange, admin.loanVerify);
    //  Admin can Approve loan payment
-   app.patch(`${API_VERSION}/payment/:loanId/:id/`, loan.loanStatusChange, admin.paymentVerify);
+   app.patch(`${API_VERSION}/payment/:loanId/:id/`,auth.authentication, auth.adminRole, loan.loanStatusChange, admin.paymentVerify);
   //  Users can pay loans
   app.post(`${API_VERSION}/loans/:id/repayment`, loan.payment, loans.payLoan);
+    //  Admin can get all repayment
+    app.get(`${API_VERSION}/payment/`, auth.authentication, auth.adminRole, admin.getAllPayment);
 };
 
 export default route;


### PR DESCRIPTION
What does this PR do?
Allow admin get all payments in the database

Description of Task to be completed?
An endpoint that allows only an admin user access to the database to get all payment

How should this be manually tested?
postman and heroku
Any background context you want to provide?
None >>>

What are the relevant pivotal tracker stories?
none
![all payment](https://user-images.githubusercontent.com/31935467/57866595-8300b580-77f7-11e9-92b6-613fc7885bd6.PNG)

An endpoint to grant only admin users access to the backend

[Delivers #166063012 #166049660]