### PR TITLE
Admin view all current loans (not fully repaid) & repaid

### DIFF
--- a/server/controllers/admin.js
+++ b/server/controllers/admin.js
@@ -89,7 +89,7 @@ class AdminController {
 
         status: 200,
 
-        data: loanData // return all loan
+        data: loanData // return all loans
 
       });
     }

--- a/server/controllers/loan.js
+++ b/server/controllers/loan.js
@@ -116,13 +116,11 @@ class loan {
       return response.status(200).json({
         status: statusCodes.success,
         data: foundId,
-        message: `${foundId}`
       });
     }
     return response.status(400).json({
       status: statusCodes.badRequest,
       error: 'No payment made',
-      message: `${foundId}`
     });
   }
 }


### PR DESCRIPTION
### What does this PR do?
Allow admin get only all unpaid or repaid

### Description of Task to be completed?
An endpoint that allows only an admin user access to the database to get all users that have completely paid their loans and due yet to pay

### How should this be manually tested?
postman and heroku


### Any background context you want to provide?
None >>>heroku
Admin should be able to query the database to get loan paid and unpaid

[Delivers #166048991 #166058193 #165990496]
### Screenshot
![repaid](https://user-images.githubusercontent.com/31935467/57880085-c9fda380-7815-11e9-9241-c5f924ad65d4.PNG)
![unpaid](https://user-images.githubusercontent.com/31935467/57880120-daae1980-7815-11e9-97ca-0bec6992a147.PNG)

